### PR TITLE
Relax Client App authentication for /token POSTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 2020-04-23
+* Client Applications no longer authenticate themselves with both HTTP Basic Auth headers *and* Client ID + Secret in form data during POSTs to `/token` endpoint - now just the latter.
+
 ## 2020-04-22
-* Add step in pipeline to replace invalid characters in the branch name 
+* Add step in pipeline to replace invalid characters in the branch name
 
 ## 2020-04-09
 * Store the JWT from the IdP as an attribute of the generated OAuth token for later use/retrieval

--- a/proxies/live/apiproxy/policies/BasicAuthentication.Decode.xml
+++ b/proxies/live/apiproxy/policies/BasicAuthentication.Decode.xml
@@ -1,7 +1,0 @@
-<BasicAuthentication async="false" continueOnError="false" enabled="true" name="BasicAuthentication.Decode">
-  <Operation>Decode</Operation>
-  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
-  <User ref="original.client_id"/>
-  <Password ref="original.secret"/>
-  <Source>request.header.Authorization</Source>
-</BasicAuthentication>

--- a/proxies/live/apiproxy/policies/RaiseFault.Unauthorized.xml
+++ b/proxies/live/apiproxy/policies/RaiseFault.Unauthorized.xml
@@ -1,0 +1,12 @@
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.Unauthorized">
+  <Properties/>
+  <FaultResponse>
+      <Set>
+          <Headers/>
+          <Payload contentType="text/plain"/>
+          <StatusCode>401</StatusCode>
+          <ReasonPhrase>Unauthorized</ReasonPhrase>
+      </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/live/apiproxy/policies/VerifyAPIKey.FromClientSecretFormParam.xml
+++ b/proxies/live/apiproxy/policies/VerifyAPIKey.FromClientSecretFormParam.xml
@@ -1,0 +1,4 @@
+<VerifyAPIKey async="false" continueOnError="false" enabled="true" name="VerifyAPIKey.FromClientSecretFormParam">
+  <Properties/>
+  <APIKey ref="request.formparam.client_id"/>
+</VerifyAPIKey>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -43,8 +43,13 @@
         <Flow name="Flow.PostToken">
             <Description>OAuth Token Endpoint</Description>
             <Request>
+                <!-- First two steps verify the Client Application using both client_id and client_secret form params -->
                 <Step>
-                    <Name>BasicAuthentication.Decode</Name>
+                  <Name>VerifyAPIKey.FromClientSecretFormParam</Name>
+                </Step>
+                <Step>
+                  <Name>RaiseFault.Unauthorized</Name>
+                  <Condition>request.formparam.client_secret != verifyapikey.VerifyAPIKey.FromClientSecretFormParam.client_secret</Condition>
                 </Step>
                 <Step>
                     <Name>KeyValueMapOperations.GetApigeeOauthCredentials</Name>


### PR DESCRIPTION
Client Applications no longer authenticate themselves with both HTTP Basic Auth headers *and* Client ID + Secret in form data during POSTs to `/token` endpoint - now just the latter.

## Summary
* Relax doubling-up on Authentication requirements for `/token POST`


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
