### PR TITLE
Apm 1162 fix access token expiry override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 docker.env
 
 .direnv
+.venv

--- a/proxies/live/apiproxy/policies/OAuthV2.ClientCredentialsGenerateAccessToken.xml
+++ b/proxies/live/apiproxy/policies/OAuthV2.ClientCredentialsGenerateAccessToken.xml
@@ -2,7 +2,7 @@
   <!-- This policy generates an OAuth 2.0 access token using the client_credentials grant type -->
   <Operation>GenerateAccessToken</Operation>
   <!-- 1 hour -->
-  <ExpiresIn ref="private.apigee.access_token_expiry_ms">3600000</ExpiresIn>
+  <ExpiresIn ref="apigee.access_token_expiry_ms">3600000</ExpiresIn>
   <SupportedGrantTypes>
     <GrantType>client_credentials</GrantType>
   </SupportedGrantTypes>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -198,7 +198,7 @@
                using _access_token_expiry_ms form param -->
           <Step>
             <Name>AssignMessage.AccessTokenExpiryOverride</Name>
-            <Condition>(request.formparam._access_token_expiry_ms != null) and (request.formparam._access_token_expiry_ms LesserThan private.apigee.access_token_expiry_ms)</Condition>
+            <Condition>(request.formparam._access_token_expiry_ms != null) and (request.formparam._access_token_expiry_ms LesserThan apigee.access_token_expiry_ms)</Condition>
           </Step>
           <Step>
             <Name>OAuthV2.ClientCredentialsGenerateAccessToken</Name>


### PR DESCRIPTION
## Summary

Not all usages of the variable `apigee.access_token_expiry_ms` (assigned in `proxies/live/apiproxy/policies/KeyValueMapOperations.GetVariables.xml`) were updated. Specifically this is breaking the ability to override the access token expiry for testing, and breaking one of the tests in the branch `apm-1541-application-restricted-error-scenarios`.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
