### PR TITLE
APM-2732 Make client_secret key in encryted KVM a templated variable

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -113,6 +113,7 @@ extends:
           IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
+          ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET: keycloak_client_secret
           NUM_RANDOM_LONG_INTS_FOR_STATE: 4
           RATELIMITING: ${{ variables.ratelimiting }}
       - environment: int

--- a/proxies/live/apiproxy/policies/KeyValueMapOperations.GetSecureVariables.xml
+++ b/proxies/live/apiproxy/policies/KeyValueMapOperations.GetSecureVariables.xml
@@ -7,7 +7,7 @@
   >
   <Get assignTo="private.apigee.client_secret" index="1">
     <Key>
-      <Parameter>client_secret</Parameter>
+      <Parameter>{{ ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET | default('client_secret') }}</Parameter>
     </Key>
   </Get>
   <Get assignTo="private.jwt" index="1">


### PR DESCRIPTION
This should allow the GetSecureVariables policy to pull in the
keycloak key in the `-mock` instance in the `int` environment instead
of the actual `cis2` int environment client secret.