### PR TITLE
APM-2016 Check Content-Type header before PostClient* flows

### DIFF
--- a/e2e/tests/oauth/test_oauth_endpoints.py
+++ b/e2e/tests/oauth/test_oauth_endpoints.py
@@ -340,17 +340,6 @@ class TestOauthEndpoints:
     @pytest.mark.parametrize(
         "request_data, expected_response",
         [
-            # condition 1: no data provided
-            (
-                {"data": {}},
-                {
-                    "status_code": 400,
-                    "body": {
-                        "error": "invalid_request",
-                        "error_description": "grant_type is missing",
-                    },
-                },
-            ),
             # condition 2: invalid grant type
             (
                 {

--- a/e2e/tests/oauth/test_oauth_tokens.py
+++ b/e2e/tests/oauth/test_oauth_tokens.py
@@ -135,10 +135,10 @@ class TestOauthTokens:
             }
         )
 
-        assert resp['status_code'] == 400
+        assert resp['status_code'] == 415
         assert resp['body'] == {
             "error": "invalid_request",
-            "error_description": "grant_type is missing"
+            "error_description": "Content-Type header must be application/x-www-urlencoded"
         }
 
     @pytest.mark.apm_1010

--- a/proxies/live/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.AddPayloadToPing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <AssignMessage continueOnError="false" enabled="true" name="AssignMessage.AddPayloadToPing" async="false">
   <Set>
-    <Payload>{"version":"{{ DEPLOYED_VERSION }}","revision":"{apiproxy.revision}","releaseId":"{{ RELEASE_RELEASEID }}","commitId":"{{ SOURCE_COMMIT_ID }}"}</Payload>
+    <Payload contentType="application/json">{"version":"{{ DEPLOYED_VERSION }}","revision":"{apiproxy.revision}","releaseId":"{{ RELEASE_RELEASEID }}","commitId":"{{ SOURCE_COMMIT_ID }}"}</Payload>
     <StatusCode>200</StatusCode>
     <Verb>GET</Verb>
     <Version>1.1</Version>

--- a/proxies/live/apiproxy/policies/RaiseFault.ContentTypeMustBeFormUrlEncoded.xml
+++ b/proxies/live/apiproxy/policies/RaiseFault.ContentTypeMustBeFormUrlEncoded.xml
@@ -1,0 +1,14 @@
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.ContentTypeMustBeFormUrlEncoded">
+  <FaultResponse>
+    <Set>
+      <Headers/>
+      <Payload contentType="application/json">{
+  "error": "invalid_request",
+  "error_description": "Content-Type header must be application/x-www-urlencoded",
+  "message_id": "{messageid}"
+}</Payload>
+      <StatusCode>415</StatusCode>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -271,6 +271,18 @@
             </Response>
             <Condition>(proxy.pathsuffix MatchesPath "/authorize") and (request.verb = "GET")</Condition>
         </Flow>
+        <Flow name="Flow.PostTokenInvalidMediaType">
+          <Request>
+            <Step>
+              <!-- The <Condition> check for all PostToken* flows read a request.formparam.* variable. 
+                   Requests in the wrong format (e.g. JSON) produce a hard-to-understand error message.
+                   Our docs say to set the header Content-Type: application/x-www-formurlencoded.
+                   For better user error messages, we enforce that here.-->
+              <Name>RaiseFault.ContentTypeMustBeFormUrlEncoded</Name>
+            </Step>
+          </Request>
+          <Condition>((proxy.pathsuffix MatchesPath "/token") and  (request.verb Equals "POST") and (request.header.Content-Type != "application/x-www-form-urlencoded"))</Condition>          
+        </Flow>
         <Flow name="Flow.PostTokenClientCredentials">
             <Description>OAuth Token Endpoint - Client Credentials</Description>
             <Request>
@@ -350,10 +362,6 @@
                     <Name>AssignMessage.CCJWKS</Name>
                     <Condition>ccjwks = null</Condition>
                 </Step>
-                <!-- Not sure this is necessary
-          <Step>
-            <Name>ExtractVariables.ParseJWKS</Name>
-          </Step> -->
                 <Step>
                     <Name>VerifyJWT.ClientCredentials</Name>
                 </Step>


### PR DESCRIPTION
A consumer support ticket came through with an error message that said
"unsupported_grant_type". The user had submitted their data in JSON
format rather than formdata. Adding a new error message should make
this clearer to consumers... even though it is clearly stated in the
docs:

https://digital.nhs.uk/developer/guides-and-documentation/security-and-authorisation/application-restricted-restful-apis-signed-jwt-authentication#step-5-get-an-access-token

-------

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.