### PR TITLE
AMB-1251: Added `nhs-login-keycloak` providers to pipelines

### DIFF
--- a/azure/azure-pr-pipeline.yml
+++ b/azure/azure-pr-pipeline.yml
@@ -63,7 +63,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           NUM_RANDOM_LONG_INTS_FOR_STATE: 4

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -112,7 +112,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET: keycloak_client_secret

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -112,7 +112,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET: keycloak_client_secret

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -54,7 +54,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           NUM_RANDOM_LONG_INTS_FOR_STATE: 4
@@ -79,7 +79,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET: keycloak_client_secret
@@ -112,7 +112,7 @@ extends:
         service_base_path: ${{ variables.service_base_path }}-mock
         jinja_templates:
           IDENTITY_PROVIDER_CIS2: cis2-keycloak
-          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login
+          IDENTITY_PROVIDER_NHS_LOGIN: nhs-login-keycloak
           VARIABLES_KVM: identity_service_config_keycloak
           ENCRYPTED_VARIABLES_KVM: identity-service-variables-encrypted
           ENCRYPTED_VARIABLES_KVM_KEY_CLIENT_SECRET: keycloak_client_secret

--- a/e2e/scripts/config.py
+++ b/e2e/scripts/config.py
@@ -14,8 +14,8 @@ SERVICE_NAME = environ.get(
     (f'identity-service-{ENVIRONMENT}', OAUTH_PROXY.replace('oauth2', 'identity-service'))["pr" in OAUTH_PROXY]
 )
 
-# Test API (Hello World)
-HELLO_WORLD_API_URL = f"{OAUTH_BASE_URI}/hello-world/hello/user"
+# Test API (Canary API)
+CANARY_API_URL = f"{OAUTH_BASE_URI}/canary-api"
 
 
 # Jwt Keys

--- a/e2e/scripts/generic_request.py
+++ b/e2e/scripts/generic_request.py
@@ -293,7 +293,7 @@ class GenericRequest:
             # Might be HTML
             # We need to get rid of the dynamic state here so we can compare the text to the stored value
             actual_response = sub('<input name="state" type="hidden" value="[a-zA-Z0-9_-]{36}">', "", response.text)
-
+            # import pdb; pdb.set_trace()
             assert actual_response.replace("\n", "").replace(" ", "").strip() == expected_response.replace(
                 "\n", "").replace(" ", "").strip(), f"UNEXPECTED RESPONSE: {actual_response}"
 

--- a/e2e/scripts/generic_request.py
+++ b/e2e/scripts/generic_request.py
@@ -293,7 +293,6 @@ class GenericRequest:
             # Might be HTML
             # We need to get rid of the dynamic state here so we can compare the text to the stored value
             actual_response = sub('<input name="state" type="hidden" value="[a-zA-Z0-9_-]{36}">', "", response.text)
-            # import pdb; pdb.set_trace()
             assert actual_response.replace("\n", "").replace(" ", "").strip() == expected_response.replace(
                 "\n", "").replace(" ", "").strip(), f"UNEXPECTED RESPONSE: {actual_response}"
 

--- a/e2e/tests/logging/test_attach_logging_fields.py
+++ b/e2e/tests/logging/test_attach_logging_fields.py
@@ -4,7 +4,7 @@ from api_test_utils.apigee_api_trace import ApigeeApiTraceDebug
 from time import time
 from uuid import uuid4
 
-from e2e.scripts.config import OAUTH_URL, HELLO_WORLD_API_URL, ENVIRONMENT, ID_TOKEN_NHS_LOGIN_PRIVATE_KEY_ABSOLUTE_PATH, MOCK_IDP_BASE_URL
+from e2e.scripts.config import OAUTH_URL, CANARY_API_URL, ENVIRONMENT, ID_TOKEN_NHS_LOGIN_PRIVATE_KEY_ABSOLUTE_PATH, MOCK_IDP_BASE_URL
 
 
 @pytest.mark.asyncio
@@ -14,11 +14,11 @@ class TestAttachLoggingFields:
     @pytest.mark.usefixtures('set_access_token')
     async def test_access_token_fields_for_logging_when_using_authorization_code_cis2(self, helper):
         # Given
-        apigee_trace = ApigeeApiTraceDebug(proxy=f"hello-world-{ENVIRONMENT}")
+        apigee_trace = ApigeeApiTraceDebug(proxy=f"canary-api-{ENVIRONMENT}")
 
         # When
         await apigee_trace.start_trace()
-        requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {self.oauth.access_token}"})
+        requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {self.oauth.access_token}"})
 
         # Then
         auth_type = await apigee_trace.get_apigee_variable_from_trace(name='accesstoken.auth_type')
@@ -38,7 +38,7 @@ class TestAttachLoggingFields:
     @pytest.mark.parametrize('scope', ['P9', 'P5', 'P0'])
     async def test_access_token_fields_for_logging_when_using_authorization_code_nhs_login(self, scope, helper):
         # Given
-        apigee_trace = ApigeeApiTraceDebug(proxy=f"hello-world-{ENVIRONMENT}")
+        apigee_trace = ApigeeApiTraceDebug(proxy=f"canary-api-{ENVIRONMENT}")
 
         # Make authorize request to retrieve state2
         response = await self.oauth.hit_oauth_endpoint(
@@ -110,7 +110,7 @@ class TestAttachLoggingFields:
         access_token = response['body']['access_token']
         # When
         await apigee_trace.start_trace()
-        requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
+        requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
 
         # Then
         auth_type = await apigee_trace.get_apigee_variable_from_trace(name='accesstoken.auth_type')
@@ -129,7 +129,7 @@ class TestAttachLoggingFields:
     @pytest.mark.logging
     async def test_access_token_fields_for_logging_when_using_client_credentials(self):
         # Given
-        apigee_trace = ApigeeApiTraceDebug(proxy=f"hello-world-{ENVIRONMENT}")
+        apigee_trace = ApigeeApiTraceDebug(proxy=f"canary-api-{ENVIRONMENT}")
         jwt_claims = {
             'kid': 'test-1',
             'claims': {
@@ -146,7 +146,7 @@ class TestAttachLoggingFields:
 
         # When
         await apigee_trace.start_trace()
-        requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
+        requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
 
         # Then
         auth_type = await apigee_trace.get_apigee_variable_from_trace(name='accesstoken.auth_type')
@@ -165,7 +165,7 @@ class TestAttachLoggingFields:
     @pytest.mark.logging
     async def test_access_token_fields_for_logging_when_using_token_exchange_cis2(self):
         # Given
-        apigee_trace = ApigeeApiTraceDebug(proxy=f"hello-world-{ENVIRONMENT}")
+        apigee_trace = ApigeeApiTraceDebug(proxy=f"canary-api-{ENVIRONMENT}")
 
         id_token_jwt = self.oauth.create_id_token_jwt()
         client_assertion_jwt = self.oauth.create_jwt(kid='test-1')
@@ -175,7 +175,7 @@ class TestAttachLoggingFields:
 
         # When
         await apigee_trace.start_trace()
-        requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
+        requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
 
         # Then
         auth_type = await apigee_trace.get_apigee_variable_from_trace(name='accesstoken.auth_type')
@@ -195,7 +195,7 @@ class TestAttachLoggingFields:
     @pytest.mark.parametrize('scope', ['P9', 'P5', 'P0'])
     async def test_access_token_fields_for_logging_when_using_token_exchange_nhs_login(self, scope):
         # Given
-        apigee_trace = ApigeeApiTraceDebug(proxy=f"hello-world-{ENVIRONMENT}")
+        apigee_trace = ApigeeApiTraceDebug(proxy=f"canary-api-{ENVIRONMENT}")
 
         id_token_claims = {
             "aud": "tf_-APIM-1",
@@ -242,7 +242,7 @@ class TestAttachLoggingFields:
 
         # When
         await apigee_trace.start_trace()
-        requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
+        requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
 
         # Then
         auth_type = await apigee_trace.get_apigee_variable_from_trace(name='accesstoken.auth_type')

--- a/e2e/tests/oauth/test_oauth_endpoints.py
+++ b/e2e/tests/oauth/test_oauth_endpoints.py
@@ -91,8 +91,8 @@ class TestOauthEndpoints:
         """
 
         # Make authorize request to retrieve state2
-        state = await auth_code_nhs_cis2.get_state(self.oauth)        
-        
+        state = await auth_code_nhs_cis2.get_state(self.oauth)
+
         # Make simulated auth request to authenticate and make initial callback request
         auth_code = await auth_code_nhs_cis2.make_auth_request(self.oauth, state)
         auth_code = await auth_code_nhs_cis2.make_callback_request(self.oauth, state, auth_code)
@@ -210,7 +210,7 @@ class TestOauthEndpoints:
     async def test_authorize_unsubscribed_error_condition(
         self, test_product, test_app, helper
     ):
-        await test_product.update_proxies(["hello-world-internal-dev"])
+        await test_product.update_proxies(["canary-api-internal-dev"])
         await test_app.add_api_product([test_product.name])
 
         assert await helper.send_request_and_check_output(
@@ -238,7 +238,7 @@ class TestOauthEndpoints:
     async def test_token_unsubscribed_error_condition(
         self, test_product, test_app, helper
     ):
-        await test_product.update_proxies(["hello-world-internal-dev"])
+        await test_product.update_proxies(["canary-api-internal-dev"])
         await test_app.add_api_product([test_product.name])
 
         assert await helper.send_request_and_check_output(
@@ -545,7 +545,7 @@ class TestOauthEndpoints:
     @pytest.mark.callback_endpoint
     @pytest.mark.parametrize("auth_method", [(None)])
     async def test_callback_error_conditions(self, helper, auth_code_nhs_cis2):
-        
+
         state = await auth_code_nhs_cis2.get_state(self.oauth)
         assert await helper.send_request_and_check_output(
 
@@ -768,7 +768,7 @@ class TestOauthEndpoints:
         # When
         jwt = self.oauth.create_jwt(kid="test-1")
         resp = await self.oauth.get_token_response("client_credentials", _jwt=jwt)
-        
+
         token = resp["body"]["access_token"]
 
         resp = await self.oauth.hit_oauth_endpoint(
@@ -776,7 +776,7 @@ class TestOauthEndpoints:
             endpoint="userinfo",
             headers={"Authorization": f"Bearer {token}"},
         )
-       
+
 
         # Then
         assert expected_status_code == resp['status_code']

--- a/e2e/tests/oauth/test_oauth_tokens.py
+++ b/e2e/tests/oauth/test_oauth_tokens.py
@@ -1,9 +1,8 @@
 from uuid import uuid4
 import pytest
 from time import sleep, time
-from e2e.scripts.config import HELLO_WORLD_API_URL, ID_TOKEN_NHS_LOGIN_PRIVATE_KEY_ABSOLUTE_PATH
 import sys
-from e2e.scripts.config import HELLO_WORLD_API_URL, ID_TOKEN_NHS_LOGIN_PRIVATE_KEY_ABSOLUTE_PATH, MOCK_IDP_BASE_URL
+from e2e.scripts.config import CANARY_API_URL, ID_TOKEN_NHS_LOGIN_PRIVATE_KEY_ABSOLUTE_PATH, MOCK_IDP_BASE_URL
 import requests
 
 
@@ -17,7 +16,7 @@ class TestOauthTokens:
     def test_access_token(self, helper):
         assert helper.check_endpoint(
             verb="GET",
-            endpoint=HELLO_WORLD_API_URL,
+            endpoint=CANARY_API_URL,
             expected_status_code=200,
             expected_response={"message": "hello user!"},
             headers={
@@ -61,7 +60,7 @@ class TestOauthTokens:
     async def test_invalid_access_token(self, token: str, helper):
         assert helper.check_endpoint(
             verb="POST",
-            endpoint=HELLO_WORLD_API_URL,
+            endpoint=CANARY_API_URL,
             expected_status_code=404,
             expected_response="""
             <!DOCTYPE html>
@@ -81,7 +80,7 @@ class TestOauthTokens:
     def test_missing_access_token(self, helper):
         assert helper.check_endpoint(
             verb="POST",
-            endpoint=HELLO_WORLD_API_URL,
+            endpoint=CANARY_API_URL,
             expected_status_code=404,
             expected_response="""
             <!DOCTYPE html>
@@ -109,7 +108,7 @@ class TestOauthTokens:
         # Check token still works after access token has expired
         assert helper.check_endpoint(
             verb="GET",
-            endpoint=HELLO_WORLD_API_URL,
+            endpoint=CANARY_API_URL,
             expected_status_code=401,
             expected_response={
                 "fault": {
@@ -225,7 +224,7 @@ class TestOauthTokens:
 
         assert helper.check_endpoint(
             verb="GET",
-            endpoint=HELLO_WORLD_API_URL,
+            endpoint=CANARY_API_URL,
             expected_status_code=200,
             expected_response={"message": "hello user!"},
             headers={
@@ -322,7 +321,7 @@ class TestTokenExchangeTokens:
         assert resp['body']['refresh_token_expires_in'] == '43199'
 
         # Make request using access token to ensure valid
-        req = requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
+        req = requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token}"})
         assert req.status_code == 200
 
         # Get new access token using refresh token to ensure valid
@@ -333,7 +332,7 @@ class TestTokenExchangeTokens:
         assert refresh_token2
 
         # Make request using new access token to ensure valid
-        req2 = requests.get(f"{HELLO_WORLD_API_URL}", headers={"Authorization": f"Bearer {access_token2}"})
+        req2 = requests.get(f"{CANARY_API_URL}", headers={"Authorization": f"Bearer {access_token2}"})
         assert req2.status_code == 200
 
     async def test_cis2_token_exchange_refresh_token_become_invalid(self):
@@ -380,8 +379,8 @@ class TestTokenExchangeTokens:
     @pytest.mark.parametrize("token_expiry_ms, expected_time", [(100000, 100), (500000, 500),(700000, 600), (1000000, 600)])
     async def test_access_token_override_with_client_credentials(self, token_expiry_ms, expected_time):
         """
-        Test client credential flow access token can be overridden with a time less than 10 min(600000ms or 600s) 
-        and NOT be overridden with a time greater than 10 min(600000ms or 600s)  
+        Test client credential flow access token can be overridden with a time less than 10 min(600000ms or 600s)
+        and NOT be overridden with a time greater than 10 min(600000ms or 600s)
         """
         form_data = {
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
@@ -389,12 +388,12 @@ class TestTokenExchangeTokens:
             "grant_type": 'client_credentials',
             "_access_token_expiry_ms": token_expiry_ms
         }
-        
+
         resp = await self.oauth.get_token_response(grant_type='client_credentials', data=form_data)
 
         assert resp['status_code'] == 200
         assert int(resp['body']['expires_in']) <= expected_time
-    
+
     @pytest.mark.parametrize("token_expiry_ms, expected_time", [(100000, 100), (500000, 500),(700000, 600), (1000000, 600)])
     async def test_access_token_override_with_token_exchange(self, token_expiry_ms, expected_time):
         """
@@ -411,24 +410,24 @@ class TestTokenExchangeTokens:
             "client_assertion": client_assertion_jwt,
             "_access_token_expiry_ms": token_expiry_ms
         }
-        
+
         resp = await self.oauth.hit_oauth_endpoint("post", "token", data=form_data)
 
         assert resp['status_code'] == 200
         assert int(resp['body']['expires_in']) <= expected_time
-    
+
     @pytest.mark.parametrize("token_expiry_ms, expected_time", [(100000, 100), (500000, 500),(700000, 600), (1000000, 600)])
     async def test_access_token_override_with_authorization_code(self, token_expiry_ms, expected_time):
         """
         Test authorization code flow access token can be overridden with a time less than 10 min(600000ms or 600s)
         and NOT be overridden with a time greater than 10 min(600000ms or 600s)
         """
-        
+
         resp = await self.oauth.get_token_response(grant_type='authorization_code', timeout=token_expiry_ms)
 
         assert resp['status_code'] == 200
         assert int(resp['body']['expires_in']) <= expected_time
-    
+
     @pytest.mark.usefixtures("set_refresh_token")
     @pytest.mark.parametrize("token_expiry_ms, expected_time", [(100000, 100), (500000, 500),(700000, 600), (1000000, 600)])
     async def test_access_token_override_with_refresh_token(self, token_expiry_ms, expected_time):
@@ -444,12 +443,12 @@ class TestTokenExchangeTokens:
             "_refresh_tokens_validity_ms": 599,
             "_access_token_expiry_ms": token_expiry_ms
         }
-        
+
         resp = await self.oauth.get_token_response(grant_type='refresh_token', data=form_data)
-        
+
         assert resp['status_code'] == 200
         assert int(resp['body']['expires_in']) <= expected_time
-    
+
 @pytest.mark.asyncio
 class TestTokenRefreshExpiry:
     """Test class to confirm refresh tokens expire after the expected amount of time


### PR DESCRIPTION
## Summary
* :robot: Operational or Infrastructure Change

Modified the NHS-Login identity provider for ptl *-mock environments to point to Keycloak now that we have moved NHS Login mock from simulated auth to Keycloak.

The new target servers that these identity providers point to are added here:
https://github.com/NHSDigital/api-management-infrastructure/pull/764   


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
